### PR TITLE
Rework authorization

### DIFF
--- a/files/aptly.rb
+++ b/files/aptly.rb
@@ -230,6 +230,7 @@ class Aptly
     config = {
       'with_sources'     => false,
       'with_udebs'       => false,
+      'with_installer'   => false,
       'filter_with_deps' => false,
       'architectures'    => [],
       'environment'      => [],
@@ -244,6 +245,7 @@ class Aptly
     end
     args << '-with-sources=' + config['with_sources'].to_s
     args << '-with-udebs=' + config['with_udebs'].to_s
+    args << '-with-installer=' + config['with_installer'].to_s
     args << '-filter="' + config['filter'] + '"' unless config['filter'].empty?
 
     if Gem::Version.new(aptly_version) >= APTLY_VERSION_INTRODUCE_FORCE_COMPONENTS

--- a/functions/convert_publish_allow_from_to_requires.pp
+++ b/functions/convert_publish_allow_from_to_requires.pp
@@ -12,26 +12,49 @@
 function aptly_profile::convert_publish_allow_from_to_requires(
   Hash[String, Hash] $publish,
   Hash $prefixes = {},
+  Hash $repos = {},
   Aptly_profile::AllowFromKeywords $default_allow_from = 'prefix',
   Boolean $strict = false,
-)
->> Hash[String, Aptly_profile::PrefixRequires]
-{
+) >> Hash[String, Aptly_profile::PrefixRequires] {
 
-  $sorted_by_prefix = aptly_profile::publish_auth_order_by_prefix($publish)
+  # convert to hash with prefix => distribution_points => {}
+  $sorted_by_prefix = aptly_profile::publish_auth_order_by_prefix($publish, $repos)
+  # remove all prefixes without any authorization
   $sanitized_by_prefix = aptly_profile::publish_auth_clean_and_default_prefixes($default_allow_from, $sorted_by_prefix, $prefixes)
 
-  $sanitized_by_prefix.reduce({}) |Hash $memo, Tuple $element| {
+  $sanitized_by_prefix.reduce({}) |Hash $memo, Tuple[String, Aptly_profile::PrefixPermissions] $element| {
     $prefix = $element[0]
+    $distributions = $element[1]
 
     $expanded = aptly_profile::publish_auth_resolve_permissions_by_prefix($prefix, $element[1])
-    $shared_permissions = aptly_profile::publish_auth_resolve_shared_permissions($element[1])
+    $api_shared_permissions = $expanded
+                                .aptly_profile::publish_auth_collect_permissions_by_type('api')
+                                .aptly_profile::publish_auth_resolve_shared_permissions()
+
+    unless $api_shared_permissions.empty() {
+      assert_type(Aptly_profile::LocationRequires, $api_shared_permissions)
+    }
+
+    $public_shared_permissions = $expanded
+                                   .aptly_profile::publish_auth_collect_permissions_by_type('public')
+                                   .aptly_profile::publish_auth_resolve_shared_permissions()
+    unless $public_shared_permissions.empty() {
+      assert_type(Aptly_profile::LocationRequires, $public_shared_permissions)
+    }
 
     # @TODO: Strict mode and permissions checking. Failing if there are gaps and such.
+    $api = $api_shared_permissions.empty() ? {
+      true    => {},
+      default => { 'api' => $api_shared_permissions },
+    }
+    $pool = $public_shared_permissions.empty() ? {
+      true    => {},
+      default => {'pool' => $public_shared_permissions },
+    }
 
-    deep_merge($memo, { $prefix => {
-      'pool'  => $shared_permissions,
-      'dists' => $expanded,
-    }})
+    $prefix_expanded = $api + $pool + { 'dists' => $expanded }
+    assert_type(Aptly_profile::PrefixRequires, $prefix_expanded)
+
+    deep_merge($memo, { $prefix => $prefix_expanded })
   }
 }

--- a/functions/publish_auth_clean_and_default_prefixes.pp
+++ b/functions/publish_auth_clean_and_default_prefixes.pp
@@ -2,37 +2,66 @@
 #
 # This function will:
 # * remove any prefix that has no distributions that have authorization configuration
-# * default any distribution that has no authorization configuration in a prefix that remains after cleanup
+# * default any distributions 'public' that has no authorization configuration in a prefix that remains after cleanup
 # * the default to use for any prefix can be configured using prefix_defaults or the `default` parameter is used.
 #
-# @param default Any not undef value (since we replace undef values)
+# @param default Any 'public' not undef value (since we replace undef values)
 # @param prefixed Distributions configuration ordered by prefix.
 # @private
 function aptly_profile::publish_auth_clean_and_default_prefixes(
   NotUndef $default,
-  Hash[String, Hash] $prefixed,
-  Hash $prefix_defaults = {},
+  Hash[String, Aptly_profile::PrefixPermissions] $prefixed,
+  Hash $prefix_defaults = {}, # @TODO: Properly type prefixes.
 ) >> Hash[String, Hash[String, NotUndef, 1]] {
 
-  $filtered_all_empty_prefix = $prefixed.filter |String $prefix, Aptly_profile::PrefixPermissions $distributions| {
+  $filtered_all_empty_public_prefix = $prefixed.filter()
+      |String $prefix, Aptly_profile::PrefixPermissions $distributions| {
+
     $not_undef_size = $distributions.filter |$_name, $permissions| {
-      $permissions =~ NotUndef
+      $permissions['public'] =~ NotUndef
     }.size()
     $not_undef_size > 0
   }
 
-  $filtered_all_empty_prefix.reduce({}) |Hash $memo, Tuple $element| {
+  $public_defaulted = $filtered_all_empty_public_prefix.reduce({})
+      |Hash $memo, Tuple[String, Aptly_profile::PrefixPermissions] $element| {
     $prefix = $element[0]
+
     $default_value = $prefix in $prefix_defaults ? {
       true    => $prefix_defaults[$prefix],
       default => $default,
     }
 
     $distributions = $element[1].reduce({}) |Hash $_memo, Tuple $_element| {
-      deep_merge($_memo, { $_element[0] => pick($_element[1], $default_value) })
+      deep_merge($_memo, { $_element[0] => { 'public' => pick($_element[1]['public'], $default_value)}})
     }
 
     deep_merge($memo, { $prefix => $distributions })
   }
+
+
+  $filtered_api_only = $prefixed.reduce({}) |Hash $memo, Tuple $element| {
+    $prefix = $element[0]
+    $distributions = $element[1]
+
+    $distributions_api_only = $distributions.reduce({}) |Hash $_memo, Tuple $_element| {
+      $distro = $_element[0]
+      $permissions = $_element[1]
+      if $_element[1].dig('api') =~ NotUndef {
+        deep_merge($_memo, { $distro => {'api' => $_element[1]['api'] }})
+      }
+      else {
+        $_memo
+      }
+    }
+    if $distributions_api_only.size() > 0 {
+      deep_merge($memo, { $prefix => $distributions_api_only })
+    }
+    else {
+      $memo
+    }
+  }
+
+  deep_merge($public_defaulted, $filtered_api_only)
 
 }

--- a/functions/publish_auth_collect_permissions_by_type.pp
+++ b/functions/publish_auth_collect_permissions_by_type.pp
@@ -1,0 +1,22 @@
+# @summary Collect permissions from a sub-hash/struct
+# @param elements Hash with subhashes to get a field from.
+# @param type The subkey to fetch.
+# @return An array with all sub values that are not undef.
+# @private
+function aptly_profile::publish_auth_collect_permissions_by_type(
+  Hash[String, Hash, 1] $elements,
+  String[1] $type,
+) >> Array[NotUndef] {
+
+  $elements.reduce([]) |Array[NotUndef] $memo, Tuple $element| {
+    $distro = $element[0]
+    $permissions = $element[1]
+    if $permissions.dig($type) =~ NotUndef {
+      $memo + [ $permissions[$type] ]
+    }
+    else {
+      $memo
+    }
+  }
+
+}

--- a/functions/publish_auth_convert_allow_from_permission_to_requires.pp
+++ b/functions/publish_auth_convert_allow_from_permission_to_requires.pp
@@ -1,0 +1,21 @@
+# @summary converts permissions to apache requires and expands 'prefix' permissions
+function aptly_profile::publish_auth_convert_allow_from_permission_to_requires(
+  Aptly_profile::AllowFromPermissions $permission,
+  Variant[Enum['authenticated'], Array[String[1], 1]] $shared_permissions,
+) >> Aptly_profile::LocationRequires {
+
+  $no_prefix = $permission ? {
+    'prefix' => $shared_permissions,
+    default  => $permission,
+  }
+
+  case $no_prefix {
+    'authenticated': {
+      $resolved_permissions = 'valid-user'
+    }
+    default: {
+      $resolved_permissions = $no_prefix
+    }
+  }
+  $resolved_permissions
+}

--- a/functions/publish_auth_resolve_api_permissions.pp
+++ b/functions/publish_auth_resolve_api_permissions.pp
@@ -1,0 +1,25 @@
+# @summary Find matching repos with permissions for the publish api
+# @param publish_params The raw publish configuration
+# @param repos A hash with all configured repositories.
+# @return The combined permissions for all repos used in this publish endpoint.
+function aptly_profile::publish_auth_resolve_api_permissions(
+  Hash[String, Any] $publish_params,
+  Hash[String, Any] $repos,
+) >> Optional[Aptly_profile::AllowFromPermissions] {
+
+  $components = pick($publish_params.dig('components'), {})
+
+  $referenced_repos = $components.map |String $component, Hash $component_params| {
+    $component_params.dig('repo')
+  }.filter() |Optional[String] $p| { $p =~ NotUndef }
+
+  $repos_permissions = $referenced_repos.map() |String $repo| {
+    $repos.dig($repo, 'allow_from')
+  }
+  $shared_permissions = aptly_profile::publish_auth_resolve_shared_permissions($repos_permissions)
+
+  $return = $shared_permissions.empty() ? {
+    true    => undef,
+    default => $shared_permissions,
+  }
+}

--- a/functions/publish_auth_resolve_shared_permissions.pp
+++ b/functions/publish_auth_resolve_shared_permissions.pp
@@ -1,18 +1,24 @@
-# @summary resolve permissions to use for 'prefix'
+# @summary helper to resolve shared permissions
 #
-# As soon as any distribution is configured as 'authenticated',
+# As soon as any permissions is configured as 'authenticated',
 # the shared permissions will also be 'authenticated'
-# Otherwise, the result is a combination of all users in the prefix.
+# Otherwise, the result is a combination of all users in the provided permissions.
 #
-# @param distributions The distribution permissions within a prefix.
+# @param permissions The permissions which to resolve.
 # @return Either a valid Aptly_profile::LocationRequires or an empty array (when no users can be collected)
 function aptly_profile::publish_auth_resolve_shared_permissions(
-  Aptly_profile::PrefixPermissions $distributions,
-) >> Variant[Aptly_profile::LocationRequires, Array[String, 0, 0]] {
-  if ('authenticated' in $distributions.values()) {
+  Array[Optional[Variant[Aptly_profile::AllowFromPermissions, Aptly_profile::LocationRequires]]] $permissions,
+) >> Variant[Aptly_profile::AllowFromPermissions, Array[String, 0, 0], Aptly_profile::LocationRequires] {
+
+  $values = $permissions.filter() |$p| { $p =~ NotUndef }
+
+  if ('authenticated' in $values) {
+    $return = 'authenticated'
+  }
+  elsif ('valid-user' in $values) {
     $return = 'valid-user'
   }
   else {
-    $return = $distributions.filter() |String $_, $p| { $p =~ Array }.values().flatten().sort().unique()
+    $return = $values.filter() |Aptly_profile::AllowFromPermissions $p| { $p =~ Array }.flatten().sort().unique()
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -518,35 +518,38 @@ class aptly_profile(
     target =>  "${basename}.sec",
   }
 
-  @@::apt::key { "aptly key ${::hostname}":
-    id      => $key['fingerprint'],
-    content => $key['public_key'],
-    tag     => $facts['fqdn'],
-  }
-
-  if $gpg_import_apt {
-    ::apt::key { "aptly key ${::hostname}-local":
+  # default key has no fingerprint yet. wait till the facts pick it up
+  if $key['fingerprint'] {
+    @@::apt::key { "aptly key ${::hostname}":
       id      => $key['fingerprint'],
       content => $key['public_key'],
+      tag     => $facts['fqdn'],
     }
-  }
 
-  # Aptly expects the signing key to be in its GnuPG keyring
-  # Import/replace it
-  exec { 'aptly_profile::init import aptly GPG key in to keyring':
-    user        => $aptly_user,
-    environment => ["HOME=${aptly_homedir}"],
-    cwd         => $aptly_homedir,
-    unless      => "${real_gpg_path} --list-secret-keys ${key['fingerprint']}",
-    command     => "${real_gpg_path} --import '${basename}.sec'",
-  }
-  exec { 'aptly_profile::init update aptly GPG key in keyring':
-    refreshonly => true,
-    subscribe   => File["${basename}.sec"],
-    user        => $aptly_user,
-    environment => ["HOME=${aptly_homedir}"],
-    cwd         => $aptly_homedir,
-    command     => "/bin/rm -rf .gnupg; ${real_gpg_path} --import '${basename}.sec'",
+    if $gpg_import_apt {
+      ::apt::key { "aptly key ${::hostname}-local":
+        id      => $key['fingerprint'],
+        content => $key['public_key'],
+      }
+    }
+
+    # Aptly expects the signing key to be in its GnuPG keyring
+    # Import/replace it
+    exec { 'aptly_profile::init import aptly GPG key in to keyring':
+      user        => $aptly_user,
+      environment => ["HOME=${aptly_homedir}"],
+      cwd         => $aptly_homedir,
+      unless      => "${real_gpg_path} --list-secret-keys ${key['fingerprint']}",
+      command     => "${real_gpg_path} --import '${basename}.sec'",
+    }
+    exec { 'aptly_profile::init update aptly GPG key in keyring':
+      refreshonly => true,
+      subscribe   => File["${basename}.sec"],
+      user        => $aptly_user,
+      environment => ["HOME=${aptly_homedir}"],
+      cwd         => $aptly_homedir,
+      command     => "/bin/rm -rf .gnupg; ${real_gpg_path} --import '${basename}.sec'",
+    }
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,7 @@
 #   This value is only used if your repo_defaults does not contain `cleanup_options`.
 # @param gpg_uid            Configure the UID for a newly generated gpg key.
 # @param gpg_import_apt     Import the generated key in apt immediately.
+# @param default_key        The default private/public keypair to use (override generate)
 # @param gpg_path           Override gpg binary to use. Defaults to the gpg_path fact or '/usr/bin/gpg'
 # @param trusted_keys       Hash with trusted keys.
 # @param publish            Hash with the publish configuration.
@@ -75,6 +76,10 @@ class aptly_profile(
   Stdlib::Absolutepath $aptly_cache_dir = '/var/cache/aptly',
 
   String $gpg_uid = 'Aptly repo server signing key',
+  Optional[Struct[{
+    secret_key => String[1],
+    public_key => String[1],
+  }]] $default_key = undef,
   Boolean $gpg_import_apt = false,
   Optional[Stdlib::Absolutepath] $gpg_path = undef,
   Hash $trusted_keys = {},
@@ -461,9 +466,9 @@ class aptly_profile(
 
   $basename = "${aptly_homedir}/gpg_keys/aptly"
 
-  $existing_key = keypair::get_first_matching_value($::gpg_keys, {
-      'secret_present' => true,
-      'basename'       => 'aptly',
+  $existing_key = keypair::get_first_matching_value($::facts['gpg_keys'], {
+    'secret_present' => true,
+    'basename'       => 'aptly',
   })
 
   if $existing_key {
@@ -475,18 +480,23 @@ class aptly_profile(
       mode    => '0400',
       content => undef,
     }
-  } else { # no existing key
-    $generated_key = gpg_generate_key({
+  }
+  else { # no existing key
+    if $default_key {
+      $key = $default_key
+    }
+    else {
+      $key = gpg_generate_key({
         'uid' => $gpg_uid,
-    })
-    $key = $generated_key
+      })
+    }
 
     file { "${basename}.sec":
       ensure  => file,
       owner   => $aptly_user,
       group   => 'root',
       mode    => '0400',
-      content => $generated_key['secret_key'],
+      content => $key['secret_key'],
     }
   }
 

--- a/spec/functions/publish_auth_clean_and_default_prefixes_spec.rb
+++ b/spec/functions/publish_auth_clean_and_default_prefixes_spec.rb
@@ -20,9 +20,37 @@ describe 'aptly_profile::publish_auth_clean_and_default_prefixes' do
   it do
     is_expected.to run.with_params(
       default, {
-        'full_empty' => { 'foo' => nil, 'bar' => nil },
+        'full_empty' => {
+          'foo' => {
+            'api' => nil,
+            'public' => nil,
+          },
+          'bar' => {
+            'api' => nil,
+            'public' => nil,
+          },
+        },
       }, {}
     ).and_return({})
+  end
+
+  it do
+    is_expected.to run.with_params(
+      default, {
+        '' => {
+          'with_api' => {
+            'api' => ['userx'],
+            'public' => nil,
+          },
+        },
+      }, {}
+    ).and_return(
+      '' => {
+        'with_api' => {
+          'api' => ['userx'],
+        },
+      },
+    )
   end
 
   it do
@@ -30,35 +58,59 @@ describe 'aptly_profile::publish_auth_clean_and_default_prefixes' do
       default,
       {
         '' => {
-          'main' => ['user1'],
-          'unknown' => nil,
+          'main' => {
+            'api' => nil,
+            'public' => ['user1'],
+          },
+          'unknown' => {
+            'api' => nil,
+            'public' => nil,
+          },
         },
         'bis' => {
-          'main' => 'prefix',
-          'unknown' => nil,
+          'main' => {
+            'api' => nil,
+            'public' => 'prefix',
+          },
+          'unknown' => {
+            'api' => nil,
+            'public' => nil,
+          },
         },
         'nowork' => {
-          'foo' => ['user1'],
-          'bar' => ['user2'],
+          'foo' => {
+            'api' => nil,
+            'public' => ['user1'],
+          },
+          'bar' => {
+            'api' => nil,
+            'public' => ['user2'],
+          },
         },
         'empty' => {
-          'nope' => nil,
-          'also_nope' => nil,
+          'nope' => {
+            'api' => nil,
+            'public' => nil,
+          },
+          'also_nope' => {
+            'api' => nil,
+            'public' => nil,
+          },
         },
       },
       prefixes,
     ).and_return(
       '' => {
-        'main' => ['user1'],
-        'unknown' => 'default_allow_from',
+        'main' => { 'public' => ['user1'] },
+        'unknown' => { 'public' => 'default_allow_from' },
       },
       'bis' => {
-        'main' => 'prefix',
-        'unknown' => 'default_from_prefixes',
+        'main' => { 'public' => 'prefix' },
+        'unknown' => { 'public' => 'default_from_prefixes' },
       },
       'nowork' => {
-        'foo' => ['user1'],
-        'bar' => ['user2'],
+        'foo' => { 'public' => ['user1'] },
+        'bar' => { 'public' => ['user2'] },
       },
     )
   end

--- a/spec/functions/publish_auth_order_by_prefix_spec.rb
+++ b/spec/functions/publish_auth_order_by_prefix_spec.rb
@@ -1,62 +1,49 @@
 require 'spec_helper'
 
 describe 'aptly_profile::publish_auth_order_by_prefix' do
+  let(:repos) do
+    {
+      'repo1' => { 'allow_from' => ['deployuser'] },
+      'repo2' => { 'allow_from' => 'authenticated' },
+    }
+  end
+
   describe 'splits by prefix' do
     let(:publish) do
       {
         'foobar' => {},
-        'main/foo' => {},
-        'main/bar' => {
-          'allow_from' => ['user1'],
-        },
-      }
-    end
-
-    let(:expected_result) do
-      {
-        '' => {
-          'foobar' => nil,
-        },
-        'main' => {
-          'foo' => nil,
-          'bar' => ['user1'],
-        },
-      }
-    end
-
-    it do
-      is_expected.to run.with_params(publish).and_return(expected_result)
-    end
-  end
-
-  describe 'cleans up unwanted parameters' do
-    let(:publish) do
-      {
-        'foobar' => {},
         'main/foo' => {
-          'param1' => 'value1',
-          'param2' => 'value2',
+          'paramx' => 'foobar',
         },
         'main/bar' => {
           'allow_from' => ['user1'],
-          'param3' => 'value3',
         },
       }
     end
+
     let(:expected_result) do
       {
         '' => {
-          'foobar' => nil,
+          'foobar' => {
+            'api' => nil,
+            'public' => nil,
+          },
         },
         'main' => {
-          'foo' => nil,
-          'bar' => ['user1'],
+          'foo' => {
+            'api' => nil,
+            'public' => nil,
+          },
+          'bar' => {
+            'api' => nil,
+            'public' => ['user1'],
+          },
         },
       }
     end
 
     it do
-      is_expected.to run.with_params(publish).and_return(expected_result)
+      is_expected.to run.with_params(publish, repos).and_return(expected_result)
     end
   end
 
@@ -68,7 +55,7 @@ describe 'aptly_profile::publish_auth_order_by_prefix' do
     end
 
     it do
-      is_expected.to run.with_params(publish).and_raise_error(%r{'allow_from' for publish point 'main' expects a })
+      is_expected.to run.with_params(publish, repos).and_raise_error(%r{'allow_from' for publish point 'main' expects a })
     end
   end
 
@@ -83,15 +70,24 @@ describe 'aptly_profile::publish_auth_order_by_prefix' do
     let(:expected_result) do
       {
         '' => {
-          'not_defined' => nil,
-          'wrong_defined' => nil,
-          'specified' => ['user1'],
+          'not_defined' => {
+            'api' => nil,
+            'public' => nil,
+          },
+          'wrong_defined' => {
+            'api' => nil,
+            'public' => nil,
+          },
+          'specified' => {
+            'api' => nil,
+            'public' => ['user1'],
+          },
         },
       }
     end
 
     it do
-      is_expected.to run.with_params(publish).and_return(expected_result)
+      is_expected.to run.with_params(publish, repos).and_return(expected_result)
     end
   end
 
@@ -108,18 +104,36 @@ describe 'aptly_profile::publish_auth_order_by_prefix' do
     end
 
     it do
-      is_expected.to run.with_params(publish).and_return(
+      is_expected.to run.with_params(publish, repos).and_return(
         '' => {
-          'aaa' => nil,
-          'jjj' => ['user'],
-          'zzz' => ['aaa', 'bbb', 'ooo', 'ttt'],
+          'aaa' => {
+            'api' => nil,
+            'public' => nil,
+          },
+          'jjj' => {
+            'api' => nil,
+            'public' => ['user'],
+          },
+          'zzz' => {
+            'api' => nil,
+            'public' => ['aaa', 'bbb', 'ooo', 'ttt'],
+          },
         },
         'a' => {
-          'b' => ['user'],
+          'b' => {
+            'api' => nil,
+            'public' => ['user'],
+          },
         },
         'z' => {
-          'a' => nil,
-          'b' => nil,
+          'a' => {
+            'api' => nil,
+            'public' => nil,
+          },
+          'b' => {
+            'api' => nil,
+            'public' => nil,
+          },
         },
       )
     end

--- a/spec/functions/publish_auth_resolve_api_permissions_spec.rb
+++ b/spec/functions/publish_auth_resolve_api_permissions_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe 'aptly_profile::publish_auth_resolve_api_permissions' do
+  let(:repos) do
+    {
+      'repouserx' => { 'allow_from' => ['userx'] },
+      'repousery' => { 'allow_from' => ['usery'] },
+      'repoany' => { 'allow_from' => 'authenticated' },
+    }
+  end
+
+  describe 'single repo' do
+    let(:publish_params) do
+      {
+        'allow_from' => ['foobar'],
+        'components' => {
+          'main' => {
+            'repo' => 'repoany',
+          },
+        },
+      }
+    end
+
+    it do
+      is_expected.to run.with_params(publish_params, repos).and_return('authenticated')
+    end
+  end
+
+  describe 'multiple repos' do
+    describe 'mixed users' do
+      let(:publish_params) do
+        {
+          'allow_from' => ['foobar'],
+          'components' => {
+            'componentx' => {
+              'repo' => 'repouserx',
+            },
+            'componenty' => {
+              'repo' => 'repousery',
+            },
+          },
+        }
+      end
+
+      it do
+        is_expected.to run.with_params(publish_params, repos).and_return(['userx', 'usery'])
+      end
+    end
+
+    describe 'mixed authenticated' do
+      let(:publish_params) do
+        {
+          'allow_from' => ['foobar'],
+          'components' => {
+            'componentx' => {
+              'repo' => 'repouserx',
+            },
+            'componenta' => {
+              'repo' => 'repoany',
+            },
+          },
+        }
+      end
+
+      it do
+        is_expected.to run.with_params(publish_params, repos).and_return('authenticated')
+      end
+    end
+  end
+end

--- a/spec/functions/publish_auth_resolve_permissions_by_prefix_spec.rb
+++ b/spec/functions/publish_auth_resolve_permissions_by_prefix_spec.rb
@@ -20,37 +20,78 @@ describe 'aptly_profile::publish_auth_resolve_permissions_by_prefix' do
   end
 
   it do
-    is_expected.to run.with_params(prefix, 'foo' => ['user1']).and_return('foo' => ['user1'])
+    is_expected.to run.with_params(prefix, 'foo' => { 'public' => ['user1'] }).and_return('foo' => { 'public' => ['user1'] })
   end
 
   context 'expand prefix' do
     it do
-      is_expected.to run.with_params(prefix,                                        'bar' => 'prefix',
-                                                                                    'foo' => 'prefix').and_raise_error(%r{Unable to resolve permissions in prefix '#{prefix}'})
+      is_expected.to run.with_params(
+        prefix,
+        'bar' => { 'public' => 'prefix' },
+        'foo' => { 'public' => 'prefix' },
+      ).and_raise_error(%r{Unable to resolve permissions in prefix '#{prefix}'})
     end
 
     it do
-      is_expected.to run.with_params(prefix,                                        'foo' => 'prefix',
-                                                                                    'bar' => ['user0'],
-                                                                                    'baz' => ['user1']).and_return('foo' => ['user0', 'user1'],
-                                                                                                                   'bar' => ['user0'],
-                                                                                                                   'baz' => ['user1'])
+      is_expected.to run.with_params(
+        prefix,
+        'foo' => { 'public' => 'prefix' },
+        'bar' => { 'public' => ['user0'] },
+        'baz' => { 'public' => ['user1'] },
+      ).and_return(
+        'foo' => { 'public' => ['user0', 'user1'] },
+        'bar' => { 'public' => ['user0'] },
+        'baz' => { 'public' => ['user1'] },
+      )
     end
 
     it do
-      is_expected.to run.with_params(prefix,                                        'foo' => 'prefix',
-                                                                                    'bar' => 'authenticated').and_return('foo' => 'valid-user',
-                                                                                                                         'bar' => 'valid-user')
+      is_expected.to run.with_params(
+        prefix,
+        'foo' => { 'public' => 'prefix' },
+        'bar' => { 'public' => 'authenticated' },
+      ).and_return(
+        'foo' => { 'public' => 'valid-user' },
+        'bar' => { 'public' => 'valid-user' },
+      )
     end
 
     it do
-      is_expected.to run.with_params(prefix,                                        'foo' => 'prefix',
-                                                                                    'bar' => 'authenticated',
-                                                                                    'oof' => ['user1'],
-                                                                                    'baz' => ['user2']).and_return('foo' => 'valid-user',
-                                                                                                                   'bar' => 'valid-user',
-                                                                                                                   'oof' => ['user1'],
-                                                                                                                   'baz' => ['user2'])
+      is_expected.to run.with_params(
+        prefix,
+        'foo' => { 'public' => 'prefix' },
+        'bar' => { 'public' => 'authenticated' },
+        'oof' => { 'public' => ['user1'] },
+        'baz' => { 'public' => ['user2'] },
+      ).and_return(
+        'foo' => { 'public' => 'valid-user' },
+        'bar' => { 'public' => 'valid-user' },
+        'oof' => { 'public' => ['user1'] },
+        'baz' => { 'public' => ['user2'] },
+      )
+    end
+
+    it do
+      is_expected.to run.with_params(
+        prefix,
+        'foo' => {
+          'public' => 'prefix',
+          'api' => ['admin'],
+        },
+        'bar' => {
+          'public' => 'authenticated',
+          'api' => 'authenticated',
+        },
+      ).and_return(
+        'foo' => {
+          'public' => 'valid-user',
+          'api' => ['admin'],
+        },
+        'bar' => {
+          'public' => 'valid-user',
+          'api' => 'valid-user',
+        },
+      )
     end
   end
 end

--- a/spec/functions/publish_auth_resolve_shared_permissions_spec.rb
+++ b/spec/functions/publish_auth_resolve_shared_permissions_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'aptly_profile::publish_auth_resolve_shared_permissions' do
+  describe 'only users' do
+    let(:permissions) do
+      [
+        ['user1', 'user2'],
+        ['user3', 'user4'],
+        nil,
+      ]
+    end
+
+    it do
+      is_expected.to run.with_params(permissions).and_return(['user1', 'user2', 'user3', 'user4'])
+    end
+  end
+
+  describe 'with authenticated' do
+    let(:permissions) do
+      [
+        'authenticated',
+        ['user1', 'user2'],
+        nil,
+      ]
+    end
+
+    it do
+      is_expected.to run.with_params(permissions).and_return('authenticated')
+    end
+  end
+
+  describe 'with nothing' do
+    let(:permissions) { [nil] }
+
+    it do
+      is_expected.to run.with_params(permissions).and_return([])
+    end
+  end
+end

--- a/templates/auth/apache_auth_publish_api_prefix.conf.epp
+++ b/templates/auth/apache_auth_publish_api_prefix.conf.epp
@@ -11,17 +11,25 @@
     ''      => ':\.',
     default => $prefix,
   }
-  $shared_require = $requires['pool']
   $distribution_requires = $requires['dists']
 -%>
 
+<LocationMatch "^<%= $api_path %>/+publish/+<%= $match_prefix %>$">
+  AuthType <%= $auth_type %>
+  AuthBasicProvider file
+  AuthUserFile <%= $auth_file %>
+  <Limit POST>
+    Require <%= aptly_profile::format_require($requires['api']) %>
+  </Limit>
+</LocationMatch>
+
 # API Configuration for publish prefix '<%= $prefix %>'
 ## Distributions
-<% $distribution_requires.each |String $distro, Aptly_profile::LocationRequires $require| { -%>
+<% $distribution_requires.each |String $distro, Aptly_profile::DistroRequires $require| { -%>
 <LocationMatch "^<%= $api_path %>/+publish/+<%= $match_prefix %>/<%= $distro %>$">
   AuthType <%= $auth_type %>
   AuthBasicProvider file
   AuthUserFile <%= $auth_file %>
-  Require <%= aptly_profile::format_require($require) %>
+  Require <%= aptly_profile::format_require($require['api']) %>
 </LocationMatch>
 <% } -%>

--- a/templates/auth/apache_auth_publish_api_shared.conf.epp
+++ b/templates/auth/apache_auth_publish_api_shared.conf.epp
@@ -10,5 +10,7 @@
   AuthType <%= $auth_type %>
   AuthBasicProvider file
   AuthUserFile <%= $auth_file %>
-  Require <%= aptly_profile::format_require($require) %>
+  <Limit GET>
+    Require <%= aptly_profile::format_require($require) %>
+  </Limit>
 </LocationMatch>

--- a/templates/auth/apache_auth_publish_prefix.conf.epp
+++ b/templates/auth/apache_auth_publish_prefix.conf.epp
@@ -23,11 +23,21 @@
 </Location>
 
 ## Distributions
-<% $distribution_requires.each |String $distro, Aptly_profile::LocationRequires $require| { -%>
+<%
+
+$distribution_requires.each |String $distro, Aptly_profile::DistroRequires $require| {
+  if $require.dig('public') =~ NotUndef {
+
+-%>
 <Location "<%= $prefix_path %>dists/<%= $distro %>/">
   AuthType <%= $auth_type %>
   AuthBasicProvider file
   AuthUserFile <%= $auth_file %>
-  Require <%= aptly_profile::format_require($require) %>
+  Require <%= aptly_profile::format_require($require['public']) %>
 </Location>
-<% } -%>
+<%
+
+  }
+}
+
+-%>

--- a/types/allowfrompermissions.pp
+++ b/types/allowfrompermissions.pp
@@ -1,0 +1,1 @@
+type Aptly_profile::AllowFromPermissions = Variant[Aptly_profile::AllowFromKeywords, Array[String, 1]]

--- a/types/distropermissions.pp
+++ b/types/distropermissions.pp
@@ -1,5 +1,5 @@
-# Represent possible permissions that can be configured for a published distribution or a prefix pool. Either a keyword or an array of usernames.
-type Aptly_profile::DistroPermissions = Variant[
-  Aptly_profile::AllowFromKeywords,
-  Array[String, 1],
-]
+# Represents pre-parsed permissions for a certain distribution within a prefix.
+type Aptly_profile::DistroPermissions = Struct[{
+  public => Optional[Aptly_profile::AllowFromPermissions],
+  api    => Optional[Aptly_profile::AllowFromPermissions],
+}]

--- a/types/distrorequires.pp
+++ b/types/distrorequires.pp
@@ -1,0 +1,4 @@
+type Aptly_profile::DistroRequires = Struct[{
+  'api'    => Optional[Aptly_profile::LocationRequires],
+  'public' => Optional[Aptly_profile::LocationRequires],
+}]

--- a/types/prefixrequires.pp
+++ b/types/prefixrequires.pp
@@ -1,8 +1,6 @@
-# Represents authorization configuration for a prefix with distributions.
-type Aptly_profile::PrefixRequires = Variant[
-  Aptly_profile::LocationRequires,
-  Struct[{
-    pool  => Aptly_profile::LocationRequires,
-    dists => Hash[String, Aptly_profile::LocationRequires],
-  }]
-]
+# @summary Represents authorization configuration for a prefix with distributions.
+type Aptly_profile::PrefixRequires = Struct[{
+  Optional[api] => Aptly_profile::LocationRequires, # not required but if present, should be a valid location requirement.
+  Optional[pool] => Aptly_profile::LocationRequires, # not required but if present, should be a valid location requirement.
+  dists => Hash[String, Aptly_profile::DistroRequires, 1], # Should not be empty, cleanup should have been done already.
+}]


### PR DESCRIPTION
/api/publish now uses information from repositories that have access configured for them.