### PR TITLE
fix(files/aptly.rb): Don't quote filter param

### DIFF
--- a/files/aptly.rb
+++ b/files/aptly.rb
@@ -244,7 +244,7 @@ class Aptly
     end
     args << '-with-sources=' + config['with_sources'].to_s
     args << '-with-udebs=' + config['with_udebs'].to_s
-    args << '-filter="' + config['filter'] + '"' unless config['filter'].empty?
+    args << "-filter=#{config['filter'].to_s}" unless config['filter'].empty?
 
     if Gem::Version.new(aptly_version) >= APTLY_VERSION_INTRODUCE_FORCE_COMPONENTS
       args << '-force-components=' + config['force_components'].to_s


### PR DESCRIPTION
When using queries (e.g. `!Name (= percona-haproxy)`), Aptly's CLI parses the double quotes as part of the filter, which breaks the filter.