### PR TITLE
fix(aptly.rb): Pass components/repos as separate CLI args

### DIFF
--- a/files/aptly.rb
+++ b/files/aptly.rb
@@ -258,7 +258,9 @@ class Aptly
     args << name
     args << config['location']
     args << config['release']
-    args << config['repos'].join(' ') unless config['repos'].empty?
+
+    args.concat(config['repos']) unless config['repos'].empty?
+
     @logger.info("Creating mirror #{name} => #{config['location']}")
     run(@aptly_cmd, *args)
   end


### PR DESCRIPTION
Aptly trips over its args when passing components as a single arg string.